### PR TITLE
fix: change the output of invoice provider to byte slice without modifying payload

### DIFF
--- a/pkg/invoice/ezpay/ezpay.go
+++ b/pkg/invoice/ezpay/ezpay.go
@@ -5,7 +5,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -43,7 +42,7 @@ func PKCS7Padding(b []byte, blocksize int) ([]byte, error) {
 }
 
 // Create makes an invoice API call to ezpay
-func (c *InvoiceClient) Create() (resp map[string]interface{}, err error) {
+func (c *InvoiceClient) Create() (resp []byte, err error) {
 
 	dataURL := url.Values{}
 	for k, v := range c.Payload {
@@ -84,15 +83,12 @@ func (c *InvoiceClient) Create() (resp map[string]interface{}, err error) {
 	defer r.Body.Close()
 	// Parse response
 	respBody, _ := ioutil.ReadAll(r.Body)
-	err = json.Unmarshal(respBody, &resp)
-	if err != nil {
-		return nil, fmt.Errorf("parsing response from ezPay error:%s", err.Error())
+
+	if r.StatusCode != http.StatusOK {
+		err = fmt.Errorf("httpCode:%d", r.StatusCode)
 	}
 
-	if status, ok := resp["Status"]; ok && status != "SUCCESS" {
-		return nil, fmt.Errorf("create invoice error:%s", resp["Message"])
-	}
-	return resp, nil
+	return respBody, err
 }
 
 func get(target map[string]interface{}, key string, defaultValue interface{}) (result interface{}) {

--- a/pkg/invoice/invoice.go
+++ b/pkg/invoice/invoice.go
@@ -4,7 +4,7 @@ import "github.com/mirror-media/payment-go/pkg/invoice/ezpay"
 
 // Provider is the interface each invoice service has to implement
 type Provider interface {
-	Create() (resp map[string]interface{}, err error)
+	Create() (resp []byte, err error)
 	Validate() error
 }
 


### PR DESCRIPTION
原本的 invoice package 在遇到錯誤的時候會截取 ezpay 的錯誤回應並抽出裡面的 message，導致錯誤時回應只有字串二不是 JSON。

這個 PR 修正了這個問題，讓 function 的回應跟 ezpay 的回應內容一樣且格式是 JSON。

c.c. @nickhsine 